### PR TITLE
Includes additions and bug fixes following version 1.3.1.

### DIFF
--- a/app/models/fixity_check.rb
+++ b/app/models/fixity_check.rb
@@ -64,7 +64,9 @@ class FixityCheck < ActiveRecord::Base
     set_size
     unless size == tracked_file.size
       raise FileTracker::ModifiedFileError,
-            "Expected size: #{tracked_file.size}; actual size: #{size}"
+            I18n.t("file_tracker.error.modification.size",
+                   expected: tracked_file.size,
+                   actual: size)
     end
   end
 
@@ -72,7 +74,9 @@ class FixityCheck < ActiveRecord::Base
     set_sha1
     unless sha1 == tracked_file.sha1
       raise FileTracker::ModifiedFileError,
-            "Expected SHA1 {#{tracked_file.sha1}}; actual SHA1 {#{sha1}}"
+            I18n.t("file_tracker.error.modification.sha1",
+                   expected: tracked_file.sha1,
+                   actual: sha1)
     end
   end
 
@@ -87,11 +91,16 @@ class FixityCheck < ActiveRecord::Base
   end
 
   def track_change
-    TrackedChange.create(tracked_file: tracked_file,
-                         change_type: status,
-                         size: size,
-                         sha1: sha1,
-                         discovered_at: started_at)
+    # We probably aren't concerned about creating duplicate changes
+    # because, under normal operation, a fixity check would not be
+    # execute on a file having a pending change (i.e., not
+    # current OK).
+    TrackedChange.create!(tracked_file: tracked_file,
+                          change_type: status,
+                          size: size,
+                          sha1: sha1,
+                          discovered_at: started_at,
+                          message: message)
   end
 
 end

--- a/app/models/tracked_change.rb
+++ b/app/models/tracked_change.rb
@@ -31,12 +31,21 @@ class TrackedChange < ActiveRecord::Base
   FileTracker::Change::Type.each do |key, value|
     scope key, ->{ where(change_type: value) }
 
+    define_singleton_method "create_#{key}" do |arg|
+      create(arg.merge(change_type: value))
+    end
+
+    define_singleton_method "create_#{key}!" do |arg|
+      create!(arg.merge(change_type: value))
+    end
+
     define_method "#{key}?" do
       change_type == value
     end
 
-    define_method "#{key}!" do
+    define_method "#{key}!" do |message = nil|
       self.change_type = value
+      self.message = message if message
     end
   end
 

--- a/app/models/tracked_file.rb
+++ b/app/models/tracked_file.rb
@@ -94,9 +94,12 @@ class TrackedFile < ActiveRecord::Base
     if size != current_size
       modified!
       save if changed?
-      TrackedChange.find_or_create_by(tracked_file: self,
-                                      change_type: TrackedChange::MODIFICATION,
-                                      size: current_size)
+      message = I18n.t("file_tracker.error.modification.size",
+                       expected: size,
+                       actual: current_size)
+      TrackedChange.create_modification!(tracked_file: self,
+                                         size: current_size,
+                                         message: message)
     end
   rescue Errno::ENOENT => e
     track_deletion(e)
@@ -106,9 +109,7 @@ class TrackedFile < ActiveRecord::Base
     raise exception if new_record?
     missing!
     save if changed?
-    TrackedChange.find_or_create_by(tracked_file: self,
-                                    change_type: TrackedChange::DELETION,
-                                    change_status: TrackedChange::PENDING)
+    TrackedChange.create_deletion!(tracked_file: self)
   end
 
 end

--- a/app/services/batch_fixity_check.rb
+++ b/app/services/batch_fixity_check.rb
@@ -11,7 +11,7 @@ class BatchFixityCheck
   end
 
   def call
-    tracked_files = TrackedFile.check_fixity?.order(fixity_checked_at: :asc, created_at: :asc)
+    tracked_files = TrackedFile.check_fixity?.order(fixity_checked_at: :asc, created_at: :asc).limit(max)
     queue(tracked_files)
   end
 

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -26,6 +26,9 @@ RailsAdmin.config do |config|
   config.navigation_static_links = {
     'Queues' => '/queues',
   }
+
+  # Include empty fields on show views
+  config.compact_show_view = false
 end
 
 #

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,11 +35,6 @@ en:
     md5: MD5
     sha1: SHA1
   file_tracker:
-    status:
-      :0: OK
-      :1: MODIFIED
-      :2: MISSING
-      :3: ERROR
     change:
       type:
         :1: MODIFICATION
@@ -48,6 +43,15 @@ en:
         :-1: PENDING
         :0: ACCEPTED
         :1: REJECTED
+    error:
+      modification:
+        size: "Expected size: %{expected}; actual size: %{actual}"
+        sha1: "Expected SHA1 {%{expected}}; actual SHA1 {%{actual}}"      
+    status:
+      :0: OK
+      :1: MODIFIED
+      :2: MISSING
+      :3: ERROR
   time:
     formats:
       short: "%F"

--- a/db/migrate/20171006171222_add_message_to_tracked_changes.rb
+++ b/db/migrate/20171006171222_add_message_to_tracked_changes.rb
@@ -1,0 +1,7 @@
+class AddMessageToTrackedChanges < ActiveRecord::Migration[5.1]
+  def change
+    change_table :tracked_changes do |t|
+      t.text :message
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171006134124) do
+ActiveRecord::Schema.define(version: 20171006171222) do
 
   create_table "fixity_checks", force: :cascade do |t|
     t.string "sha1"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20171006134124) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "tracked_file_id"
+    t.text "message"
     t.index ["change_status"], name: "index_tracked_changes_on_change_status"
     t.index ["change_type"], name: "index_tracked_changes_on_change_type"
     t.index ["created_at"], name: "index_tracked_changes_on_created_at"


### PR DESCRIPTION
- Fixes missing limit in BatchFixityCheck.
- Adds message column to tracked_changes.
- Moves error message to I18n with string interpolation.