### PR TITLE
Hotfix 1.9.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'figaro'
 gem 'devise'
 gem 'omniauth-shibboleth'
 gem 'cancancan'
-gem 'duracloud-client'
+gem 'duracloud-client', '~> 0.9.1'
 
 gem 'redis', '~> 3.0'
 gem 'resque', '~> 1.27'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,8 +65,9 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
-    duracloud-client (0.9.0)
+    duracloud-client (0.9.1)
       activemodel (>= 4.2, < 6)
+      addressable (~> 2.5)
       hashie (~> 3.4)
       httpclient (~> 2.7)
       nokogiri (~> 1.6)
@@ -299,7 +300,7 @@ DEPENDENCIES
   byebug
   cancancan
   devise
-  duracloud-client
+  duracloud-client (~> 0.9.1)
   figaro
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/lib/file_tracker/version.rb
+++ b/lib/file_tracker/version.rb
@@ -1,3 +1,3 @@
 module FileTracker
-  VERSION = "1.9.0"
+  VERSION = "1.9.1"
 end


### PR DESCRIPTION
Upgrades duracloud-client to v0.9.1+ to fix issue related to
file paths having non-ASCII characters.