### PR TITLE
Adds `only_status` parameter to BatchDuracloudCheckJob.

### DIFF
--- a/app/jobs/batch_duracloud_check_job.rb
+++ b/app/jobs/batch_duracloud_check_job.rb
@@ -1,8 +1,18 @@
 class BatchDuracloudCheckJob < BatchJob
 
-  def self.perform
+  def self.perform(only_status = nil)
+    only_status ? check_by_status(only_status) : check_all
+  end
+
+  def self.check_all
     TrackedDirectory.where.not(duracloud_space: nil).each do |tracked_dir|
       tracked_dir.check_duracloud!
+    end
+  end
+
+  def self.check_by_status(status)
+    TrackedFile.ok.where(duracloud_status: status.to_i).each do |tracked_file|
+      Resque.enqueue(DuracloudCheckJob, tracked_file.id)
     end
   end
 

--- a/lib/tasks/file_tracker.rake
+++ b/lib/tasks/file_tracker.rake
@@ -55,9 +55,9 @@ EOS
     puts "Batch fixity check job queued."
   end
 
-  desc "Run the batch DuraCloud check routine."
-  task :duracloud => :environment do
-    Resque.enqueue(BatchDuracloudCheckJob)
+  desc "Run the batch DuraCloud check routine, optionally limiting tracked_files by duracloud_status."
+  task :duracloud, [:only_status] => :environment do |t, args|
+    Resque.enqueue(BatchDuracloudCheckJob, args[:only_status])
     puts "Batch DuraCloud check job queued."
   end
 


### PR DESCRIPTION
If parameter is present, the batch operation checks files
having that duracloud_status (they also must have status OK (0)).