### PR TITLE
Introduces exponential backoff into RetryOnError.wrap.

### DIFF
--- a/app/models/concerns/has_fixity.rb
+++ b/app/models/concerns/has_fixity.rb
@@ -2,7 +2,7 @@ require 'digest'
 
 module HasFixity
 
-  RETRIABLE_IO_ERRORS = [ Errno::EAGAIN, Errno::EBADF, Errno::EIO, Errno::EADDRNOTAVAIL ]
+  RETRIABLE_IO_ERRORS = [ Errno::EAGAIN, Errno::EBADF, Errno::EIO ]
 
   def reset_fixity
     assign_attributes(sha1: nil, md5: nil, size: nil)

--- a/app/models/retry_on_error.rb
+++ b/app/models/retry_on_error.rb
@@ -1,14 +1,16 @@
 class RetryOnError
   include ActiveModel::Model
 
-  class_attribute :attempts, :wait
+  class_attribute :attempts, :wait, :backoff
   self.attempts = 3
   self.wait = 5
+  self.backoff = 3
 
   attr_accessor :exceptions
 
   validates_presence_of :exceptions
   validates_numericality_of :attempts, only_integer: true, greater_than: 0
+  validates_numericality_of :backoff, only_integer: true, greater_than_or_equal_to: 1
   validates_numericality_of :wait, greater_than_or_equal_to: 0
 
   def self.wrap(exceptions, **options, &block)
@@ -19,12 +21,13 @@ class RetryOnError
   def wrap(&block)
     validate!
     retries = 0
+
     begin
       block.call
     rescue *exceptions => e
       if retries < attempts
+        sleep(wait * (backoff ** retries))
         retries += 1
-        sleep wait
         retry
       end
       raise

--- a/spec/models/retry_on_error_spec.rb
+++ b/spec/models/retry_on_error_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RetryOnError do
   let(:path) { File.join(fixture_path, "nypl.jpg") }
   let(:block) { proc { File.size(path) } }
   let(:exceptions) { [ Errno::EAGAIN, Errno::EIO ] }
-  subject { described_class.new(exceptions: exceptions, wait: 0.1) }
+  subject { described_class.new(exceptions: exceptions, wait: 0.1, backoff: 1) }
 
   describe "when the block does not raise an exception" do
     it "returns the value of the block" do


### PR DESCRIPTION
Removes Errno::EADDRNOTAVAIL from HasFixity::RETRIABLE_IO_ERRORS
because it's not really an I/O and probably isn't arising in
those wrapped blacks anyway.