### PR TITLE
Directory inventory now uses `find`.

### DIFF
--- a/app/jobs/inventory_job.rb
+++ b/app/jobs/inventory_job.rb
@@ -1,7 +1,9 @@
 class InventoryJob < BatchJob
 
   def self.perform
-    TrackedDirectory.all.each(&:track!)
+    TrackedDirectory.all.each do |tracked_dir|
+      Resque.enqueue(TrackDirectoryJob, tracked_dir.id)
+    end
   end
 
 end

--- a/app/jobs/track_directory_job.rb
+++ b/app/jobs/track_directory_job.rb
@@ -1,20 +1,10 @@
-require 'find'
-
 class TrackDirectoryJob < ApplicationJob
 
   self.queue = :inventory
 
-  def self.perform(dir)
-    files = []
-    Find.find(dir) do |path|
-      if File.directory?(path) && path != dir
-        Resque.enqueue(self, path)
-        Find.prune
-      elsif File.file?(path)
-        files << path
-      end
-    end
-    TrackedFile.track!(*files)
+  def self.perform(tracked_directory_id)
+    dir = TrackedDirectory.find(tracked_directory_id)
+    dir.track!
   end
 
 end


### PR DESCRIPTION
The previous method was generating `Errno::EADDRNOTAVAIL` exceptions
indicating problems with opening new TCP sockets to Redis
which were concerning.