### PR TITLE
Inventory process ignores empty files.

### DIFF
--- a/app/models/tracked_directory.rb
+++ b/app/models/tracked_directory.rb
@@ -45,7 +45,7 @@ class TrackedDirectory < ActiveRecord::Base
   end
 
   def track
-    IO.popen(["find", path, "-type", "f"]) do |io|
+    IO.popen(["find", path, "-type", "f", "-not", "-empty"]) do |io|
       while io.gets
         path = $_.chomp
         TrackedFile.track!(path)

--- a/app/models/tracked_file.rb
+++ b/app/models/tracked_file.rb
@@ -7,7 +7,7 @@ class TrackedFile < ActiveRecord::Base
   has_many :fixity_checks, dependent: :destroy
   has_many :tracked_changes, dependent: :destroy
 
-  validates :path, file_exists: true, readable: true, uniqueness: true, on: :create
+  validates :path, file_exists: true, file_not_empty: true, readable: true, uniqueness: true, on: :create
   validates_inclusion_of :status, in: FileTracker::Status.values
 
   before_save :set_size, unless: :size?

--- a/app/validators/file_exists_validator.rb
+++ b/app/validators/file_exists_validator.rb
@@ -1,8 +1,12 @@
 class FileExistsValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
-    unless File.file?(value)
-      record.errors[attribute] << (options[:message] || "does not exist or is not a file")
+    if File.file?(value)
+      if File.symlink?(value)
+        record.errors[attribute] << "cannot be a symbolic link"
+      end
+    else
+      record.errors[attribute] << "does not exist or is not a file"
     end
   end
 

--- a/app/validators/file_not_empty_validator.rb
+++ b/app/validators/file_not_empty_validator.rb
@@ -1,0 +1,9 @@
+class FileNotEmptyValidator < ActiveModel::EachValidator
+
+  def validate_each(record, attribute, value)
+    if File.zero?(value)
+      record.errors[attribute] << "is an empty file"
+    end
+  end
+
+end

--- a/spec/models/tracked_directory_spec.rb
+++ b/spec/models/tracked_directory_spec.rb
@@ -6,11 +6,14 @@ RSpec.describe TrackedDirectory do
     let(:path) { fixture_path }
     subject { described_class.create!(path: path) }
     before { subject.track! }
-    specify {
-      file = subject.tracked_files.first
-      expect(file.size).to eq 410226
-      expect(file.path).to eq File.join(path, "nypl.jpg")
-    }
+    it "tracks files" do
+      file = File.join(subject.path, "nypl.jpg")
+      expect(subject.tracked_files.pluck(:path)).to include(file)
+    end
+    it "excludes empty files" do
+      empty_file = File.join(subject.path, "empty.txt")
+      expect(subject.tracked_files.pluck(:path)).not_to include(empty_file)
+    end
   end
 
   describe "validation" do


### PR DESCRIPTION
Adds validations to file path:
- File path cannot be a symlink.
- File cannot be empty.