### PR TITLE
Adds Errno::EHOSTDOWN to list of retriable errors (closes #49).

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Set variables in `config/application.yml`.  See the `figaro` gem documentation f
     FILE_TRACKER_DB_USER       Database user name (default: `file_tracker`)
     FILE_TRACKER_LOG_DIR       Log directory for TrackedFile logger (default: Rails log directory)
     FILE_TRACKER_LOG_SHIFT_AGE Log shift age for TrackedFile logger (default: weekly; see Ruby Logger documentation)
-    FILE_TRACKER_TRACK_MOVES   Set to enable tracking of (probably) file moving within a tracked directory (default: false [not set])
     FIXITY_CHECK_PERIOD        Integer number of days after which fixity should be re-checked (default: 60)
     LARGE_FILE_THRESHHOLD      Integer byte size, above which a file is considered "large" for purposes of job queueing (default: 1000000000 [= 1GB])
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,4 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
-  def after_sign_out_path_for(resource_or_scope)
-    FileTracker.after_sign_out_path
-  end
-
 end

--- a/app/models/concerns/has_fixity.rb
+++ b/app/models/concerns/has_fixity.rb
@@ -2,7 +2,7 @@ require 'digest'
 
 module HasFixity
 
-  RETRIABLE_IO_ERRORS = [ Errno::EAGAIN, Errno::EBADF, Errno::EIO, Errno::EBUSY ]
+  RETRIABLE_IO_ERRORS = [ Errno::EAGAIN, Errno::EBADF, Errno::EIO, Errno::EBUSY, Errno::EHOSTDOWN ]
 
   def reset_fixity
     assign_attributes(sha1: nil, size: nil)

--- a/app/models/tracked_file.rb
+++ b/app/models/tracked_file.rb
@@ -117,7 +117,7 @@ class TrackedFile < ActiveRecord::Base
   end
 
   def log_created
-    if FileTracker.track_moves && other_file = moved_from
+    if other_file = moved_from
       msg = I18n.t("file_tracker.log.message.moved_from") % other_file.path
       log(:moved, msg)
       other_file.destroy
@@ -127,7 +127,7 @@ class TrackedFile < ActiveRecord::Base
   end
 
   def log_destroyed
-    if FileTracker.track_moves && other_file = moved_to
+    if other_file = moved_to
       msg = I18n.t("file_tracker.log.message.moved_to") % other_file.path
       log(:moved, msg)
     else

--- a/lib/file_tracker.rb
+++ b/lib/file_tracker.rb
@@ -5,10 +5,6 @@ require 'file_tracker/status'
 
 module FileTracker
 
-  mattr_accessor :after_sign_out_path do
-    ENV.fetch("AFTER_SIGN_OUT_PATH", "/")
-  end
-
   mattr_accessor :batch_fixity_check_limit do
     ENV.fetch("BATCH_FIXITY_CHECK_LIMIT", 10**5).to_i
   end
@@ -35,10 +31,6 @@ module FileTracker
 
   mattr_accessor :redis_namespace do
     ENV.fetch("REDIS_NAMESPACE", "resque:FileTracker")
-  end
-
-  mattr_accessor :track_moves do
-    !!ENV.fetch("FILE_TRACKER_TRACK_MOVES", false)
   end
 
 end

--- a/spec/models/tracked_file_spec.rb
+++ b/spec/models/tracked_file_spec.rb
@@ -30,23 +30,9 @@ RSpec.describe TrackedFile do
         described_class.create!(path: path2)
         FileUtils.mv(path2, path1)
       end
-      describe "and move tracking is enabled" do
-        before do
-          allow(FileTracker).to receive(:track_moves) { true }
-        end
-        it "logs the file as MOVED" do
-          expect(subject).to receive(:log).with(:moved, "Probably moved from: #{path2}")
-          subject.save!
-        end
-      end
-      describe "and move tracking is disabled" do
-        before do
-          allow(FileTracker).to receive(:track_moves) { false }
-        end
-        it "logs the file as ADDED" do
-          expect(subject).to receive(:log).with(:added)
-          subject.save!
-        end
+      it "logs the file as MOVED" do
+        expect(subject).to receive(:log).with(:moved, "Probably moved from: #{path2}")
+        subject.save!
       end
       after { FileUtils.remove_entry_secure(dir.path) }
     end
@@ -117,23 +103,9 @@ RSpec.describe TrackedFile do
         FileUtils.mv(path1, path2)
         described_class.create!(path: path2)
       end
-      describe "and move tracking is enabled" do
-        before do
-          allow(FileTracker).to receive(:track_moves) { true }
-        end
-        it "logs the file as MOVED" do
-          expect(subject).to receive(:log).with(:moved, "Probably moved to: #{path2}")
-          subject.destroy
-        end
-      end
-      describe "and move tracking is disabled" do
-        before do
-          allow(FileTracker).to receive(:track_moves) { false }
-        end
-        it "logs the file as REMOVED" do
-          expect(subject).to receive(:log).with(:removed)
-          subject.destroy
-        end
+      it "logs the file as MOVED" do
+        expect(subject).to receive(:log).with(:moved, "Probably moved to: #{path2}")
+        subject.destroy
       end
       after { FileUtils.remove_entry_secure(dir.path) }
     end


### PR DESCRIPTION
Removes unused config settings: track_moves, after_sign_out_path.